### PR TITLE
 chore(github-actions): change old set-output to env var output

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -19,10 +19,11 @@ jobs:
     steps:
       - name: Fetch remote repo
         id: repo-version
+        # echo "::set-output name=version::$v"
         run: |
           repo=https://github.com/${{ env.repo-owner }}/${{ env.repo-name }}.git
           v=$(git ls-remote --tags --sort=-v:refname $repo | cut -f 1 | head -n 1)
-          echo "::set-output name=version::$v"
+          echo "version=$v" >> $GITHUB_OUTPUT
 
   test:
     needs: [fetch]


### PR DESCRIPTION
From https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/, use the new env vars.